### PR TITLE
#26 implement board annotations rendering and interaction

### DIFF
--- a/common/src/main/kotlin/codes/nibby/yi/go/Annotation.kt
+++ b/common/src/main/kotlin/codes/nibby/yi/go/Annotation.kt
@@ -1,0 +1,63 @@
+package codes.nibby.yi.go
+
+import java.util.*
+
+abstract class Annotation constructor(val type: AnnotationType, val x: Int, val y: Int) {
+
+    abstract class PointAnnotation(type: AnnotationType, x: Int, y: Int) : Annotation(type, x, y) {
+
+        override fun equals(other: Any?): Boolean {
+            other?.let {
+                if (other is PointAnnotation) {
+                    return this.type == other.type && this.x == other.x && this.y == other.y
+                }
+            }
+            return super.equals(other)
+        }
+
+        override fun hashCode(): Int {
+            return Objects.hash(type, x, y)
+        }
+
+        override fun toString(): String {
+            return "$type at ($x, $y)"
+        }
+    }
+
+    class Triangle(x: Int, y: Int) : PointAnnotation(AnnotationType.TRIANGLE, x, y)
+
+    class Square(x: Int, y: Int) : PointAnnotation(AnnotationType.SQUARE, x, y)
+
+    class Circle(x: Int, y: Int) : PointAnnotation(AnnotationType.CIRCLE, x, y)
+
+    class Cross(x: Int, y: Int) : PointAnnotation(AnnotationType.CROSS, x, y)
+
+    class Fade(x: Int, y: Int) : PointAnnotation(AnnotationType.FADE, x, y)
+
+
+    abstract class DirectionalAnnotation(type: AnnotationType, x: Int, y: Int, val xEnd: Int, val yEnd: Int) : Annotation(type, x, y) {
+        override fun equals(other: Any?): Boolean {
+            other?.let {
+                if (other is DirectionalAnnotation) {
+                    return this.type == other.type && this.x == other.x && this.y == other.y
+                            && this.xEnd == other.xEnd && this.yEnd == other.yEnd
+                }
+            }
+
+            return false
+        }
+
+        override fun hashCode(): Int {
+            return Objects.hash(type, x, y, xEnd, yEnd)
+        }
+
+        override fun toString(): String {
+            return "$type from ($x, $y) to ($xEnd, $yEnd)"
+        }
+    }
+
+    class Line(xStart: Int, yStart: Int, xEnd: Int, yEnd: Int) : DirectionalAnnotation(AnnotationType.LINE, xStart, yStart, xEnd, yEnd)
+
+    class Arrow(xStart: Int, yStart: Int, xEnd: Int, yEnd: Int) : DirectionalAnnotation(AnnotationType.ARROW, xStart, yStart, xEnd, yEnd)
+
+}

--- a/common/src/main/kotlin/codes/nibby/yi/go/AnnotationType.kt
+++ b/common/src/main/kotlin/codes/nibby/yi/go/AnnotationType.kt
@@ -1,0 +1,14 @@
+package codes.nibby.yi.go
+
+enum class AnnotationType {
+
+    CIRCLE,
+    TRIANGLE,
+    SQUARE,
+    CROSS,
+    FADE,
+    LABEL,
+    LINE,
+    ARROW
+
+}

--- a/common/src/main/kotlin/codes/nibby/yi/go/GameStateUpdate.kt
+++ b/common/src/main/kotlin/codes/nibby/yi/go/GameStateUpdate.kt
@@ -15,7 +15,8 @@ class GameStateUpdate(val type: Type,
                       val primaryMove: StoneData?,
                       val captures: Set<StoneData>,
                       val stateHash: Long,
-                      val helperStoneUpdates: HashSet<StoneData>) {
+                      val helperStoneUpdates: HashSet<StoneData>,
+                      val annotationsOnThisNode: HashSet<Annotation>) {
 
     enum class Type {
         MOVE_PLAYED,

--- a/common/src/main/kotlin/codes/nibby/yi/go/GameStateUpdateFactory.kt
+++ b/common/src/main/kotlin/codes/nibby/yi/go/GameStateUpdateFactory.kt
@@ -6,15 +6,15 @@ package codes.nibby.yi.go
 internal object GameStateUpdateFactory {
 
     fun createForProposedMove(primaryMove: StoneData, captures: HashSet<StoneData>, stateHash: Long): GameStateUpdate
-        = GameStateUpdate(GameStateUpdate.Type.MOVE_PLAYED, primaryMove, captures, stateHash, HashSet())
+        = GameStateUpdate(GameStateUpdate.Type.MOVE_PLAYED, primaryMove, captures, stateHash, HashSet(), HashSet())
 
     fun createForRootNode(emptyPositionStateHash: Long): GameStateUpdate
-        = GameStateUpdate(GameStateUpdate.Type.ROOT, null, HashSet(), emptyPositionStateHash, HashSet())
+        = GameStateUpdate(GameStateUpdate.Type.ROOT, null, HashSet(), emptyPositionStateHash, HashSet(), HashSet())
 
     fun createForPassMove(currentPositionStateHash: Long): GameStateUpdate
-        = GameStateUpdate(GameStateUpdate.Type.PASS, null, HashSet(), currentPositionStateHash, HashSet())
+        = GameStateUpdate(GameStateUpdate.Type.PASS, null, HashSet(), currentPositionStateHash, HashSet(), HashSet())
 
     fun createForResignationMove(currentPositionStateHash: Long): GameStateUpdate
-        = GameStateUpdate(GameStateUpdate.Type.RESIGN, null, HashSet(), currentPositionStateHash, HashSet())
+        = GameStateUpdate(GameStateUpdate.Type.RESIGN, null, HashSet(), currentPositionStateHash, HashSet(), HashSet())
 
 }

--- a/common/src/main/kotlin/codes/nibby/yi/go/GoGameModel.kt
+++ b/common/src/main/kotlin/codes/nibby/yi/go/GoGameModel.kt
@@ -4,6 +4,7 @@ import codes.nibby.yi.common.MoveNode
 import codes.nibby.yi.common.MoveTree
 import codes.nibby.yi.go.rules.GoGameRulesHandler
 import java.util.*
+import kotlin.collections.HashSet
 
 /**
  * Represents one game of Go.
@@ -130,9 +131,12 @@ class GoGameModel(val boardWidth: Int, val boardHeight: Int, val rules: GoGameRu
         var prisonersBlack = 0
 
         var currentStateHash = stateHasher.computeEmptyPositionHash(boardWidth, boardHeight)
+        var annotations = HashSet<Annotation>();
 
         // Build the board state by traversing the history and apply the delta from root up to gameNode
-        gameNode.getPathToRoot().forEach { node ->
+        val pathToRoot = gameNode.getPathToRoot()
+
+        pathToRoot.forEach { node ->
             node.data?.let { stateUpdate ->
                 positionState.apply(stateUpdate)
                 prisonersWhite += stateUpdate.captures.stream().filter { capture -> capture.stoneColor == GoStoneColor.BLACK }.count().toInt()
@@ -141,10 +145,20 @@ class GoGameModel(val boardWidth: Int, val boardHeight: Int, val rules: GoGameRu
             }
         }
 
-        val gameState = GoGameState(this, positionState, gameNode, prisonersWhite, prisonersBlack, currentStateHash)
+        annotations = pathToRoot.last.data!!.annotationsOnThisNode;
+
+        val gameState = GoGameState(this, positionState, gameNode, prisonersWhite, prisonersBlack, annotations, currentStateHash)
         this.stateCache[gameNode.getDistanceToRoot()] = gameState
 
         return gameState
+    }
+
+    fun addAnnotationOnThisMove(annotation: Annotation) {
+        addAnnotationsOnThisMove(annotation)
+    }
+
+    fun addAnnotationsOnThisMove(vararg annotations: Annotation) {
+        annotations.forEach { currentNode.data!!.annotationsOnThisNode.add(it) }
     }
 
     fun getAnnotationsOnThisMove(): Set<Annotation> {

--- a/common/src/main/kotlin/codes/nibby/yi/go/GoGameModel.kt
+++ b/common/src/main/kotlin/codes/nibby/yi/go/GoGameModel.kt
@@ -147,6 +147,10 @@ class GoGameModel(val boardWidth: Int, val boardHeight: Int, val rules: GoGameRu
         return gameState
     }
 
+    fun getAnnotationsOnThisMove(): Set<Annotation> {
+        return currentNode.data!!.annotationsOnThisNode
+    }
+
     fun getCurrentMoveNumber(): Int {
         return currentNode.getDistanceToRoot()
     }

--- a/common/src/main/kotlin/codes/nibby/yi/go/GoGameState.kt
+++ b/common/src/main/kotlin/codes/nibby/yi/go/GoGameState.kt
@@ -14,6 +14,7 @@ import codes.nibby.yi.common.MoveNode
  * @param representedNode The [MoveNode] this game state represents
  * @param prisonersBlack Number of prisoners black has captured at this point
  * @param prisonersWhite Number of prisoners white has captured at this point
+ * @param annotations The annotations present in this state
  *
  * @see GoGameStateHelper
  */
@@ -22,4 +23,5 @@ class GoGameState(private val gameModel: GoGameModel,
                   val representedNode: MoveNode<GameStateUpdate>,
                   val prisonersWhite: Int,
                   val prisonersBlack: Int,
+                  val annotations: Set<Annotation>,
                   val stateHash: Long)

--- a/common/src/main/kotlin/codes/nibby/yi/go/MoveSequence.kt
+++ b/common/src/main/kotlin/codes/nibby/yi/go/MoveSequence.kt
@@ -20,6 +20,16 @@ class MoveSequence constructor(private val game: GoGameModel) {
     }
 
     /**
+     * Synonymous to [GoGameModel.addAnnotationOnThisMove]
+     *
+     * @see [GoGameModel.addAnnotationOnThisMove]
+     */
+    fun annotate(annotation: Annotation): MoveSequence {
+        game.addAnnotationOnThisMove(annotation)
+        return this
+    }
+
+    /**
      * Synonymous to [GoGameModel.playPass].
      *
      * @see [GoGameModel.playPass]

--- a/common/test/unit/codes/nibby/yi/go/AnnotationEqualityTest.kt
+++ b/common/test/unit/codes/nibby/yi/go/AnnotationEqualityTest.kt
@@ -1,0 +1,48 @@
+package codes.nibby.yi.go
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class AnnotationEqualityTest {
+
+    @Test
+    fun `point annotations with different type but same location are not equal`() {
+        val triangle = Annotation.Triangle(0, 0)
+        val square = Annotation.Square(0, 0)
+
+        Assertions.assertNotEquals(triangle, square)
+    }
+
+    @Test
+    fun `point annotations with same type and same location are equal`() {
+        val triangle = Annotation.Triangle(0, 0)
+        val anotherTriangle = Annotation.Triangle(0, 0)
+
+        Assertions.assertEquals(triangle, anotherTriangle)
+    }
+
+    @Test
+    fun `directional annotations with same type and same vector are equal`() {
+        val line = Annotation.Line(0, 0, 1, 1)
+        val anotherLine = Annotation.Line(0, 0, 1, 1)
+
+        Assertions.assertEquals(line, anotherLine)
+    }
+
+    @Test
+    fun `directional annotations with different type and same vector are not equal`() {
+        val arrow = Annotation.Arrow(0, 0, 1, 1)
+        val line = Annotation.Line(0, 0, 1, 1)
+
+        Assertions.assertNotEquals(arrow, line)
+    }
+
+    @Test
+    fun `directional annotations with same type but inverted direction are not equal`() {
+        val line = Annotation.Arrow(0, 0, 1, 1)
+        val anotherLine = Annotation.Line(1, 1, 0, 0)
+
+        Assertions.assertNotEquals(line, anotherLine)
+    }
+
+}

--- a/common/test/unit/codes/nibby/yi/go/ZobristHasherTest.kt
+++ b/common/test/unit/codes/nibby/yi/go/ZobristHasherTest.kt
@@ -3,6 +3,7 @@ package codes.nibby.yi.go
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.util.*
+import kotlin.collections.HashSet
 
 class ZobristHasherTest {
 
@@ -14,7 +15,7 @@ class ZobristHasherTest {
         val zobrist = ZobristHasher(gameModel.boardWidth, gameModel.boardHeight)
         val gamePosition = GoGamePosition(boardWidth, boardHeight)
         val currentNode = gameModel.currentNode
-        val state = GoGameState(gameModel, gamePosition, currentNode, 0, 0, 0)
+        val state = GoGameState(gameModel, gamePosition, currentNode, 0, 0, HashSet(), 0)
 
         val firstHash = zobrist.computeStateHash(state, boardWidth, boardHeight)
         val secondHash = zobrist.computeStateHash(state, boardWidth, boardHeight)
@@ -51,7 +52,7 @@ class ZobristHasherTest {
             }
         }
 
-        val state = GoGameState(gameModel, gamePosition, currentNode, 0, 0, 0)
+        val state = GoGameState(gameModel, gamePosition, currentNode, 0, 0, HashSet(), 0)
 
         // Hash twice
         val firstHash = zobrist.computeStateHash(state, boardWidth, boardHeight)

--- a/editor/src/main/java/codes/nibby/yi/editor/Main.java
+++ b/editor/src/main/java/codes/nibby/yi/editor/Main.java
@@ -2,6 +2,7 @@ package codes.nibby.yi.editor;
 
 import codes.nibby.yi.editor.gui.board.GameBoard;
 import codes.nibby.yi.editor.settings.Settings;
+import codes.nibby.yi.go.Annotation;
 import codes.nibby.yi.go.GoGameRules;
 import codes.nibby.yi.go.GoGameModel;
 import javafx.application.Application;
@@ -16,9 +17,31 @@ public class Main extends Application {
     public void start(Stage primaryStage) throws Exception {
         Settings.load();
         GoGameModel game = new GoGameModel(19, 19, GoGameRules.CHINESE);
+        game.beginMoveSequence()
+                .playMove(0, 0)
+                .playMove(1, 0)
+                .playMove(0, 1)
+                .playMove(1, 1)
+                .playMove(0, 2)
+                .playMove(1, 2)
+                .playMove(0, 3)
+                .playMove(1, 3)
+                .playMove(0, 4)
+                .playMove(1, 4)
+                .annotate(new Annotation.Triangle(0, 0))
+                .annotate(new Annotation.Triangle(1, 0))
+                .annotate(new Annotation.Square(0, 1))
+                .annotate(new Annotation.Square(1, 1))
+                .annotate(new Annotation.Circle(0, 2))
+                .annotate(new Annotation.Circle(1, 2))
+                .annotate(new Annotation.Cross(0, 3))
+                .annotate(new Annotation.Cross(1, 3))
+                .annotate(new Annotation.Fade(0, 4))
+                .annotate(new Annotation.Fade(1, 4));
 
         GameBoard board = new GameBoard();
         board.setModel(game);
+        board.setEditable(false);
 
         Scene scene = new Scene(board.getComponent(), 800, 600);
         primaryStage.setScene(scene);

--- a/editor/src/main/java/codes/nibby/yi/editor/Main.java
+++ b/editor/src/main/java/codes/nibby/yi/editor/Main.java
@@ -37,7 +37,9 @@ public class Main extends Application {
                 .annotate(new Annotation.Cross(0, 3))
                 .annotate(new Annotation.Cross(1, 3))
                 .annotate(new Annotation.Fade(0, 4))
-                .annotate(new Annotation.Fade(1, 4));
+                .annotate(new Annotation.Fade(1, 4))
+                .annotate(new Annotation.Line(0, 5, 1, 5))
+                .annotate(new Annotation.Arrow(0, 6, 1, 6));
 
         GameBoard board = new GameBoard();
         board.setModel(game);

--- a/editor/src/main/java/codes/nibby/yi/editor/gui/board/AnnotationRenderer.java
+++ b/editor/src/main/java/codes/nibby/yi/editor/gui/board/AnnotationRenderer.java
@@ -1,0 +1,101 @@
+package codes.nibby.yi.editor.gui.board;
+
+import codes.nibby.yi.go.Annotation;
+import codes.nibby.yi.go.GoStoneColor;
+import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.paint.Color;
+
+public final class AnnotationRenderer {
+
+    private AnnotationRenderer() { }
+
+    public static void render(Annotation annotation, GoStoneColor stone, GraphicsContext g, GameBoardManager manager) {
+
+        // TODO: Work out how to color the annotation based on the underlying stone and board texture
+
+        if (annotation instanceof Annotation.PointAnnotation) {
+            double pointAnnotationSize = manager.size.getPointAnnotationSizeInPixels();
+            double[] position = manager.size.getPointAnnotationRenderPosition(annotation.getX(), annotation.getY());
+            double x = position[0];
+            double y = position[1];
+
+            switch (annotation.getType()) {
+                case TRIANGLE:
+                    renderTriangle(g, x, y, pointAnnotationSize);
+                    break;
+                case SQUARE:
+                    renderSquare(g, x, y, pointAnnotationSize);
+                    break;
+                case CIRCLE:
+                    renderCircle(g, x, y, pointAnnotationSize);
+                    break;
+                case CROSS:
+                    renderCross(g, x, y, pointAnnotationSize);
+                    break;
+                case FADE:
+                    renderFade(g, x, y, pointAnnotationSize);
+                    break;
+                default:
+                    unsupportedType(annotation);
+                    break;
+            }
+        } else if (annotation instanceof Annotation.DirectionalAnnotation) {
+            var directional = (Annotation.DirectionalAnnotation) annotation;
+            double stoneSize = manager.size.getStoneSizeInPixels();
+            double[] start = manager.size.getGridRenderPosition(directional.getX(), directional.getY(), 0d);
+            double[] end = manager.size.getGridRenderPosition(directional.getXEnd(), directional.getYEnd(), 0d);
+
+            double xStart = start[0];
+            double yStart = start[1];
+            double xEnd = end[0];
+            double yEnd = end[1];
+
+            switch (annotation.getType()) {
+                case LINE:
+                    renderLine(g, xStart, yStart, xEnd, yEnd, stoneSize);
+                    break;
+                case ARROW:
+                    renderArrow(g, xStart, yStart, xEnd, yEnd, stoneSize);
+                    break;
+                default:
+                    unsupportedType(annotation);
+                    break;
+            }
+
+        } else {
+            unsupportedType(annotation);
+        }
+    }
+
+    private static void renderArrow(GraphicsContext g, double xStart, double yStart, double xEnd, double yEnd, double stoneSize) {
+
+    }
+
+    private static void renderLine(GraphicsContext g, double xStart, double yStart, double xEnd, double yEnd, double stoneSize) {
+
+    }
+
+    private static void renderFade(GraphicsContext g, double x, double y, double annotationSize) {
+
+    }
+
+    private static void renderCross(GraphicsContext g, double x, double y, double annotationSize) {
+
+    }
+
+    private static void renderCircle(GraphicsContext g, double x, double y, double annotationSize) {
+
+    }
+
+    private static void renderSquare(GraphicsContext g, double x, double y, double annotationSize) {
+        
+    }
+
+    private static void renderTriangle(GraphicsContext g, double x, double y, double annotationSize) {
+
+    }
+
+    private static void unsupportedType(Annotation annotation) {
+        throw new IllegalStateException("Unsupported annotation type: " + annotation.getClass().toString());
+    }
+}

--- a/editor/src/main/java/codes/nibby/yi/editor/gui/board/AnnotationRenderer.java
+++ b/editor/src/main/java/codes/nibby/yi/editor/gui/board/AnnotationRenderer.java
@@ -1,98 +1,154 @@
 package codes.nibby.yi.editor.gui.board;
 
+import codes.nibby.yi.editor.utilities.ShapeUtilities;
 import codes.nibby.yi.go.Annotation;
 import codes.nibby.yi.go.GoStoneColor;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.paint.Color;
+import javafx.scene.shape.Rectangle;
 
 public final class AnnotationRenderer {
 
     private AnnotationRenderer() { }
 
-    public static void render(Annotation annotation, GoStoneColor stone, GraphicsContext g, GameBoardManager manager) {
-
-        // TODO: Work out how to color the annotation based on the underlying stone and board texture
+    public static void render(Annotation annotation, GraphicsContext g, GameBoardManager manager) {
 
         if (annotation instanceof Annotation.PointAnnotation) {
-            double pointAnnotationSize = manager.size.getPointAnnotationSizeInPixels();
-            double[] position = manager.size.getPointAnnotationRenderPosition(annotation.getX(), annotation.getY());
-            double x = position[0];
-            double y = position[1];
-
-            switch (annotation.getType()) {
-                case TRIANGLE:
-                    renderTriangle(g, x, y, pointAnnotationSize);
-                    break;
-                case SQUARE:
-                    renderSquare(g, x, y, pointAnnotationSize);
-                    break;
-                case CIRCLE:
-                    renderCircle(g, x, y, pointAnnotationSize);
-                    break;
-                case CROSS:
-                    renderCross(g, x, y, pointAnnotationSize);
-                    break;
-                case FADE:
-                    renderFade(g, x, y, pointAnnotationSize);
-                    break;
-                default:
-                    unsupportedType(annotation);
-                    break;
-            }
+            renderPointAnnotation((Annotation.PointAnnotation) annotation, g, manager);
         } else if (annotation instanceof Annotation.DirectionalAnnotation) {
-            var directional = (Annotation.DirectionalAnnotation) annotation;
-            double stoneSize = manager.size.getStoneSizeInPixels();
-            double[] start = manager.size.getGridRenderPosition(directional.getX(), directional.getY(), 0d);
-            double[] end = manager.size.getGridRenderPosition(directional.getXEnd(), directional.getYEnd(), 0d);
-
-            double xStart = start[0];
-            double yStart = start[1];
-            double xEnd = end[0];
-            double yEnd = end[1];
-
-            switch (annotation.getType()) {
-                case LINE:
-                    renderLine(g, xStart, yStart, xEnd, yEnd, stoneSize);
-                    break;
-                case ARROW:
-                    renderArrow(g, xStart, yStart, xEnd, yEnd, stoneSize);
-                    break;
-                default:
-                    unsupportedType(annotation);
-                    break;
-            }
-
+            renderDirectionalAnnotation((Annotation.DirectionalAnnotation) annotation, g, manager);
         } else {
             unsupportedType(annotation);
         }
     }
 
-    private static void renderArrow(GraphicsContext g, double xStart, double yStart, double xEnd, double yEnd, double stoneSize) {
+    private static void renderPointAnnotation(Annotation.PointAnnotation annotation, GraphicsContext g, GameBoardManager manager) {
+        double stoneSize = manager.size.getStoneSizeInPixels();
+        double[] position = manager.size.getStoneRenderPosition(annotation.getX(), annotation.getY());
+        double x = position[0];
+        double y = position[1];
+
+        Rectangle stoneBounds = new Rectangle(x, y, stoneSize, stoneSize);
+        Rectangle annoBounds = ShapeUtilities.clip(stoneBounds, stoneSize / 4d);
+
+        // TODO: Work out how to color the annotation based on the underlying stone and board texture
+        Color color;
+        var stone = manager.model.getCurrentGamePosition().getStoneColorAt(annotation.getX(), annotation.getY());
+
+        if (stone == GoStoneColor.BLACK) {
+            color = Color.WHITE;
+        } else {
+            color = Color.BLACK;
+        }
+
+        double originalLineWidth = g.getLineWidth();
+        double lineWidth = getLineWidth(stoneSize);
+        g.setLineWidth(lineWidth);
+        g.setStroke(color);
+
+        switch (annotation.getType()) {
+            case TRIANGLE:
+                renderTriangle(g, annoBounds.getX(), annoBounds.getY(), annoBounds.getWidth(), color);
+                break;
+            case SQUARE:
+                renderSquare(g, annoBounds.getX(), annoBounds.getY(), annoBounds.getWidth());
+                break;
+            case CIRCLE:
+                // Use slightly bigger radius so that it appears roughly the same size as a square
+                var bigBounds = ShapeUtilities.clip(stoneBounds, stoneSize / 5d);
+                renderCircle(g, bigBounds.getX(), bigBounds.getY(), bigBounds.getWidth(), color);
+                break;
+            case CROSS:
+                renderCross(g, annoBounds.getX(), annoBounds.getY(), annoBounds.getWidth(), color);
+                break;
+            case FADE:
+                // Stone size + stone gap size, tiles nicely with adjacent fade annotations
+                double gridUnitSize = manager.size.getGridUnitSizeInPixels();
+                renderFade(g, x, y, gridUnitSize, color);
+                break;
+            default:
+                unsupportedType(annotation);
+                break;
+        }
+
+        g.setLineWidth(originalLineWidth);
+    }
+
+    private static void renderDirectionalAnnotation(Annotation.DirectionalAnnotation annotation, GraphicsContext g, GameBoardManager manager) {
+        double stoneSize = manager.size.getStoneSizeInPixels();
+        double[] start = manager.size.getGridRenderPosition(annotation.getX(), annotation.getY(), 0d);
+        double[] end = manager.size.getGridRenderPosition(annotation.getXEnd(), annotation.getYEnd(), 0d);
+
+        double xStart = start[0];
+        double yStart = start[1];
+        double xEnd = end[0];
+        double yEnd = end[1];
+
+        // TODO: Work out how to color the annotation based on the underlying stone and board texture
+        //       Also deal with the optical illusion that white-on-black appears lot larger than black-on-white
+        Color color = Color.BLACK;
+
+        switch (annotation.getType()) {
+            case LINE:
+                renderLine(g, xStart, yStart, xEnd, yEnd, stoneSize, color);
+                break;
+            case ARROW:
+                renderArrow(g, xStart, yStart, xEnd, yEnd, stoneSize, color);
+                break;
+            default:
+                unsupportedType(annotation);
+                break;
+        }
+    }
+
+    private static void renderArrow(GraphicsContext g, double xStart, double yStart, double xEnd, double yEnd, double stoneSize, Color color) {
 
     }
 
-    private static void renderLine(GraphicsContext g, double xStart, double yStart, double xEnd, double yEnd, double stoneSize) {
-
+    private static void renderLine(GraphicsContext g, double xStart, double yStart, double xEnd, double yEnd, double stoneSize, Color color) {
     }
 
-    private static void renderFade(GraphicsContext g, double x, double y, double annotationSize) {
-
+    private static void renderFade(GraphicsContext g, double x, double y, double size, Color color) {
+        g.setFill(new Color(0d, 0d, 0d, 0.25d));
+        g.fillRect(x, y, size, size);
     }
 
-    private static void renderCross(GraphicsContext g, double x, double y, double annotationSize) {
-
+    private static void renderCross(GraphicsContext g, double x, double y, double size, Color color) {
+        g.strokeLine(x, y, x+size, y+size);
+        g.strokeLine(x+size, y, x, y+size);
     }
 
-    private static void renderCircle(GraphicsContext g, double x, double y, double annotationSize) {
-
+    private static void renderCircle(GraphicsContext g, double x, double y, double size, Color color) {
+        g.strokeOval(x, y, size, size);
     }
 
-    private static void renderSquare(GraphicsContext g, double x, double y, double annotationSize) {
-        
+    private static void renderSquare(GraphicsContext g, double x, double y, double size) {
+        g.strokeRect(x, y, size, size);
+    }
+    
+    private static void renderTriangle(GraphicsContext g, double x, double y, double size, Color color) {
+        // Looks better when it's not 1:1 ratio
+        double centerX = x + size / 2;
+        double centerY = y + size / 5 * 2;
+
+        // Lists (x,y) points in a clockwise fashion, starting at 12 o'clock
+        var xPoints = new double[] {
+            centerX,
+            centerX + size / 2,
+            centerX - size / 2
+        };
+
+        var yPoints = new double[] {
+            centerY - size / 5 * 2,
+            centerY + size / 2,
+            centerY + size / 2,
+        };
+
+        g.strokePolygon(xPoints, yPoints, 3);
     }
 
-    private static void renderTriangle(GraphicsContext g, double x, double y, double annotationSize) {
-
+    private static double getLineWidth(double stoneSize) {
+        return stoneSize / 16d;
     }
 
     private static void unsupportedType(Annotation annotation) {

--- a/editor/src/main/java/codes/nibby/yi/editor/gui/board/AnnotationRenderer.java
+++ b/editor/src/main/java/codes/nibby/yi/editor/gui/board/AnnotationRenderer.java
@@ -48,7 +48,7 @@ public final class AnnotationRenderer {
 
         switch (annotation.getType()) {
             case TRIANGLE:
-                renderTriangle(g, annoBounds.getX(), annoBounds.getY(), annoBounds.getWidth(), color);
+                renderTriangle(g, annoBounds.getX(), annoBounds.getY(), annoBounds.getWidth());
                 break;
             case SQUARE:
                 renderSquare(g, annoBounds.getX(), annoBounds.getY(), annoBounds.getWidth());
@@ -56,15 +56,15 @@ public final class AnnotationRenderer {
             case CIRCLE:
                 // Use slightly bigger radius so that it appears roughly the same size as a square
                 var bigBounds = ShapeUtilities.clip(stoneBounds, stoneSize / 5d);
-                renderCircle(g, bigBounds.getX(), bigBounds.getY(), bigBounds.getWidth(), color);
+                renderCircle(g, bigBounds.getX(), bigBounds.getY(), bigBounds.getWidth());
                 break;
             case CROSS:
-                renderCross(g, annoBounds.getX(), annoBounds.getY(), annoBounds.getWidth(), color);
+                renderCross(g, annoBounds.getX(), annoBounds.getY(), annoBounds.getWidth());
                 break;
             case FADE:
                 // Stone size + stone gap size, tiles nicely with adjacent fade annotations
                 double gridUnitSize = manager.size.getGridUnitSizeInPixels();
-                renderFade(g, x, y, gridUnitSize, color);
+                renderFade(g, x, y, gridUnitSize);
                 break;
             default:
                 unsupportedType(annotation);
@@ -87,13 +87,17 @@ public final class AnnotationRenderer {
         // TODO: Work out how to color the annotation based on the underlying stone and board texture
         //       Also deal with the optical illusion that white-on-black appears lot larger than black-on-white
         Color color = Color.BLACK;
+        g.setStroke(color);
+
+        double lineWidth = getLineWidth(stoneSize) * 2;
+        g.setLineWidth(lineWidth);
 
         switch (annotation.getType()) {
             case LINE:
-                renderLine(g, xStart, yStart, xEnd, yEnd, stoneSize, color);
+                renderLine(g, xStart, yStart, xEnd, yEnd);
                 break;
             case ARROW:
-                renderArrow(g, xStart, yStart, xEnd, yEnd, stoneSize, color);
+                renderArrow(g, xStart, yStart, xEnd, yEnd, stoneSize);
                 break;
             default:
                 unsupportedType(annotation);
@@ -101,24 +105,29 @@ public final class AnnotationRenderer {
         }
     }
 
-    private static void renderArrow(GraphicsContext g, double xStart, double yStart, double xEnd, double yEnd, double stoneSize, Color color) {
+    private static void renderArrow(GraphicsContext g, double xStart, double yStart, double xEnd, double yEnd, double stoneSize) {
+        double tipSize = stoneSize / 4d;
 
+        renderLine(g, xStart, yStart, xEnd, yEnd);
+        renderLine(g, xEnd, yEnd, xEnd - tipSize, yStart - tipSize);
+        renderLine(g, xEnd, yEnd, xEnd - tipSize, yStart + tipSize);
     }
 
-    private static void renderLine(GraphicsContext g, double xStart, double yStart, double xEnd, double yEnd, double stoneSize, Color color) {
+    private static void renderLine(GraphicsContext g, double xStart, double yStart, double xEnd, double yEnd) {
+        g.strokeLine(xStart, yStart, xEnd, yEnd);
     }
 
-    private static void renderFade(GraphicsContext g, double x, double y, double size, Color color) {
+    private static void renderFade(GraphicsContext g, double x, double y, double size) {
         g.setFill(new Color(0d, 0d, 0d, 0.25d));
         g.fillRect(x, y, size, size);
     }
 
-    private static void renderCross(GraphicsContext g, double x, double y, double size, Color color) {
+    private static void renderCross(GraphicsContext g, double x, double y, double size) {
         g.strokeLine(x, y, x+size, y+size);
         g.strokeLine(x+size, y, x, y+size);
     }
 
-    private static void renderCircle(GraphicsContext g, double x, double y, double size, Color color) {
+    private static void renderCircle(GraphicsContext g, double x, double y, double size) {
         g.strokeOval(x, y, size, size);
     }
 
@@ -126,7 +135,7 @@ public final class AnnotationRenderer {
         g.strokeRect(x, y, size, size);
     }
     
-    private static void renderTriangle(GraphicsContext g, double x, double y, double size, Color color) {
+    private static void renderTriangle(GraphicsContext g, double x, double y, double size) {
         // Looks better when it's not 1:1 ratio
         double centerX = x + size / 2;
         double centerY = y + size / 5 * 2;

--- a/editor/src/main/java/codes/nibby/yi/editor/gui/board/GameBoard.java
+++ b/editor/src/main/java/codes/nibby/yi/editor/gui/board/GameBoard.java
@@ -65,6 +65,10 @@ public final class GameBoard {
         content.forEach(canvas -> canvas.onGameModelSet(game, manager));
     }
 
+    public void setEditable(boolean editable) {
+        manager.edit.setEditable(editable);
+    }
+
     /**
      * Invoked when there is an update to the {@link GoGameModel}. The model must
      * be identical to the model that was last {@link #setModel(GoGameModel) initialized}.

--- a/editor/src/main/java/codes/nibby/yi/editor/gui/board/GameBoardMainCanvas.java
+++ b/editor/src/main/java/codes/nibby/yi/editor/gui/board/GameBoardMainCanvas.java
@@ -1,6 +1,7 @@
 package codes.nibby.yi.editor.gui.board;
 
 import codes.nibby.yi.editor.settings.Settings;
+import codes.nibby.yi.go.Annotation;
 import codes.nibby.yi.go.GoGameModel;
 import codes.nibby.yi.go.GoStoneColor;
 import javafx.scene.canvas.GraphicsContext;
@@ -31,7 +32,8 @@ final class GameBoardMainCanvas extends GameBoardCanvas {
         g.clearRect(0, 0, getWidth(), getHeight());
 
         BoardRenderer.render(g, manager);
-        StoneRenderer.render(g, manager);
+        BoardStoneRenderer.render(g, manager);
+        BoardAnnotationRenderer.render(g, manager);
     }
 
     private static final class BoardRenderer {
@@ -201,7 +203,7 @@ final class GameBoardMainCanvas extends GameBoardCanvas {
 
     }
 
-    private static final class StoneRenderer {
+    private static final class BoardStoneRenderer {
 
         public static void render(GraphicsContext g, GameBoardManager manager) {
             //TODO: Temporary code, polish later
@@ -219,5 +221,17 @@ final class GameBoardMainCanvas extends GameBoardCanvas {
                 PresetStoneStyle.getDefaultValue().render(g, manager, state, x, y);
             }
         }
+    }
+
+    private static final class BoardAnnotationRenderer {
+
+        public static void render(GraphicsContext g, GameBoardManager manager) {
+            Set<Annotation> annotations = manager.model.getCurrentGameState().getAnnotations();
+
+            for (Annotation annotation : annotations) {
+                AnnotationRenderer.render(annotation, g, manager);
+            }
+        }
+
     }
 }

--- a/editor/src/main/java/codes/nibby/yi/editor/gui/board/GameBoardSize.java
+++ b/editor/src/main/java/codes/nibby/yi/editor/gui/board/GameBoardSize.java
@@ -22,6 +22,7 @@ public final class GameBoardSize {
     // These are percentages of gridBounds.
     private double stoneGapSize;
     private double stoneSize;
+    private double pointAnnotationSize;
     private double gridUnitSize; // Size of the stone + gap at each intersection
 
     private double stoneShadowRadius;
@@ -86,6 +87,7 @@ public final class GameBoardSize {
         double percentageStoneGap = 0.01d;
         stoneGapSize = gridUnitSize * percentageStoneGap;
         stoneSize = gridUnitSize - stoneGapSize;
+        pointAnnotationSize = stoneSize / 4 * 3;
         gridBounds = scaledGridBounds;
 
         stoneShadowRadius = stoneSize / 8d;
@@ -131,6 +133,10 @@ public final class GameBoardSize {
 
     public double getStoneShadowOffset() {
         return stoneShadowOffset;
+    }
+
+    public double[] getPointAnnotationRenderPosition(int gridX, int gridY) {
+        return getGridRenderPosition(gridX, gridY, pointAnnotationSize);
     }
 
     public double[] getStoneRenderPosition(int gridX, int gridY) {
@@ -277,6 +283,10 @@ public final class GameBoardSize {
 
     public double getGridUnitSizeInPixels() {
         return gridUnitSize;
+    }
+
+    public double getPointAnnotationSizeInPixels() {
+        return pointAnnotationSize;
     }
 
     private double getPixelValue(double percentage, Rectangle rectangle) {

--- a/editor/src/main/java/codes/nibby/yi/editor/gui/board/GameBoardSize.java
+++ b/editor/src/main/java/codes/nibby/yi/editor/gui/board/GameBoardSize.java
@@ -22,7 +22,6 @@ public final class GameBoardSize {
     // These are percentages of gridBounds.
     private double stoneGapSize;
     private double stoneSize;
-    private double pointAnnotationSize;
     private double gridUnitSize; // Size of the stone + gap at each intersection
 
     private double stoneShadowRadius;
@@ -87,7 +86,6 @@ public final class GameBoardSize {
         double percentageStoneGap = 0.01d;
         stoneGapSize = gridUnitSize * percentageStoneGap;
         stoneSize = gridUnitSize - stoneGapSize;
-        pointAnnotationSize = stoneSize / 4 * 3;
         gridBounds = scaledGridBounds;
 
         stoneShadowRadius = stoneSize / 8d;
@@ -133,10 +131,6 @@ public final class GameBoardSize {
 
     public double getStoneShadowOffset() {
         return stoneShadowOffset;
-    }
-
-    public double[] getPointAnnotationRenderPosition(int gridX, int gridY) {
-        return getGridRenderPosition(gridX, gridY, pointAnnotationSize);
     }
 
     public double[] getStoneRenderPosition(int gridX, int gridY) {

--- a/editor/src/main/java/codes/nibby/yi/editor/gui/board/GameBoardSize.java
+++ b/editor/src/main/java/codes/nibby/yi/editor/gui/board/GameBoardSize.java
@@ -1,5 +1,6 @@
 package codes.nibby.yi.editor.gui.board;
 
+import codes.nibby.yi.editor.utilities.ShapeUtilities;
 import javafx.scene.shape.Rectangle;
 
 import java.util.Optional;
@@ -15,7 +16,6 @@ public final class GameBoardSize {
     private LayoutRectangle boardBorderBounds;
     private LayoutRectangle boardBounds;
 
-    private final double percentageBoardShadowOffset = 0.012d;
     private LayoutRectangle coordinateLabelBounds;
     private Rectangle gridBounds;
 
@@ -57,7 +57,7 @@ public final class GameBoardSize {
         // scale value).
 
         // We need to calculate a scaled version of stone size at this point to maintain the correct board ratio
-        Rectangle gridFitRatio = centerFit(stage, (double) gridWidth / (double) gridHeight, 0d);
+        Rectangle gridFitRatio = ShapeUtilities.centerFit(stage, (double) gridWidth / (double) gridHeight, 0d);
 
         // Doesn't really matter the size of the grid bounds at this point, the proportion is what matters.
         // We will scale everything to the correct size later.
@@ -248,6 +248,7 @@ public final class GameBoardSize {
      * @return The amount of offset in both x and y direction of the board border shadow
      */
     public double getBoardBorderShadowOffsetInPixels() {
+        double percentageBoardShadowOffset = 0.012d;
         return percentageBoardShadowOffset * getBoardBounds().getHeight();
     }
 
@@ -285,127 +286,8 @@ public final class GameBoardSize {
         return gridUnitSize;
     }
 
-    public double getPointAnnotationSizeInPixels() {
-        return pointAnnotationSize;
-    }
-
     private double getPixelValue(double percentage, Rectangle rectangle) {
         return percentage * Math.min(rectangle.getWidth(), rectangle.getHeight());
-    }
-
-    /**
-     * Calculates the bounds of the component if it is centered relative to the container.
-     *
-     * @param container The container to center within
-     * @param component The component to center
-     * @return The bounds of the component after it is centered
-     */
-    static Rectangle center(Rectangle container, Rectangle component) {
-        double x = container.getX() + container.getWidth() / 2 - component.getWidth() / 2;
-        double y = container.getY() + container.getHeight() / 2 - component.getHeight() / 2;
-        return new Rectangle(x, y, component.getWidth(), component.getHeight());
-    }
-
-    /**
-     * Finds the largest rectangle with the given width to height ratio that can fit inside the container.
-     *
-     * @param container The container to fit the rectangle within
-     * @param targetWidthToHeightRatio The width to height ratio of the fitted rectangle
-     * @param percentageInsets Amount of margin for the fitted rectangle on each side, expressed as a percentage of the shorter side of the container.
-     *                         For example, 0.05d (5%) on a 100x200 container means a margin of 5px on all sides of the fitted rectangle.
-     * @return The largest rectangle within the container that complies with the target width to height ratio
-     */
-    static Rectangle centerFit(Rectangle container, double targetWidthToHeightRatio, double percentageInsets) {
-        boolean containerWidthWider = container.getWidth() > container.getHeight();
-        boolean fitWidthWider = targetWidthToHeightRatio > 1;
-
-        double fitInsets;
-
-        if (containerWidthWider) {
-            fitInsets = container.getHeight() * percentageInsets;
-        } else {
-            fitInsets = container.getWidth() * percentageInsets;
-        }
-
-        double fitWidth, fitHeight;
-        double scaleFactor;
-
-        if (fitWidthWider) {
-            // If fit by width, component size is constrained by height
-            fitWidth = container.getWidth();
-            fitHeight = fitWidth / targetWidthToHeightRatio;
-
-            scaleFactor = fitHeight / container.getHeight();
-        } else {
-            // If fit by height, component size is constrained by width
-            fitHeight = container.getHeight();
-            fitWidth = fitHeight * targetWidthToHeightRatio;
-
-            scaleFactor = fitWidth / container.getWidth();
-        }
-
-        if (scaleFactor > 1d) {
-            fitWidth /= scaleFactor;
-            fitHeight /= scaleFactor;
-        }
-
-        double fitX = container.getX() + container.getWidth() / 2 - fitWidth / 2;
-        double fitY = container.getY() + container.getHeight() / 2 - fitHeight / 2;
-
-        return new Rectangle(fitX + fitInsets, fitY + fitInsets, fitWidth - 2 * fitInsets, fitHeight - 2 * fitInsets);
-    }
-
-    /**
-     * Trims the given bounds on all four sides by an inset. The result is a smaller rectangle
-     * centered within bounds.
-     *
-     * @param bounds The bounds to trim
-     * @param insets Amount to trim from all sides on the bounds, in pixel units
-     * @return The clipped bounds
-     */
-    static Rectangle clip(Rectangle bounds, double insets) {
-        return clip(bounds.getX(), bounds.getY(), bounds.getWidth(), bounds.getHeight(), insets);
-    }
-
-    /**
-     * Trims the given bounds on all four sides by an inset. The result is a smaller rectangle
-     * centered within bounds.
-     *
-     * @param x x position of the bound rectangle
-     * @param y y position of the bound rectangle
-     * @param w width of the bound rectangle
-     * @param h height of the bound rectangle
-     * @param insets Amount to trim from all sides on the bounds, in pixel units
-     * @return The clipped bounds
-     */
-    static Rectangle clip(double x, double y, double w, double h, double insets) {
-        return clip(x, y, w, h, insets, insets, insets, insets);
-    }
-
-    /**
-     * Trims the given bounds on each side by a custom inset. The result is a smaller rectangle.
-     * </p>
-     * The rectangle is not guaranteed to be centered within the bounds if the amount trimmed on each side is not identical.
-     *
-     * @param x x position of the bound rectangle
-     * @param y y position of the bound rectangle
-     * @param w width of the bound rectangle
-     * @param h height of the bound rectangle
-     * @param insetLeft Amount to trim from left of the rectangle, in pixel units
-     * @param insetTop Amount to trim from top of the rectangle, in pixel units
-     * @param insetRight Amount to trim from right of the rectangle, in pixel units
-     * @param insetBottom Amount to trim from bottom of the rectangle, in pixel units
-     * @return The clipped bounds
-     */
-    static Rectangle clip(double x, double y, double w, double h, double insetLeft, double insetTop, double insetRight, double insetBottom) {
-        double newX, newY, newWidth, newHeight;
-
-        newX = x + insetLeft;
-        newY = y + insetTop;
-        newWidth = w - (insetLeft + insetRight);
-        newHeight = h - (insetTop + insetBottom);
-
-        return new Rectangle(newX, newY, newWidth, newHeight);
     }
 
     /**
@@ -537,7 +419,7 @@ public final class GameBoardSize {
             double fitContainerHeight = containerHeight - (marginTop + marginBottom) - margin * 2;
             Rectangle fitContainerBounds = new Rectangle(fitContainerX, fitContainerY, fitContainerWidth, fitContainerHeight);
 
-            Rectangle fitBounds = centerFit(fitContainerBounds, widthToHeightRatio, 0);
+            Rectangle fitBounds = ShapeUtilities.centerFit(fitContainerBounds, widthToHeightRatio, 0);
             double fitScale = fitBounds.getWidth() / originalWidth;
 
             setWidth(fitBounds.getWidth());

--- a/editor/src/main/java/codes/nibby/yi/editor/utilities/ShapeUtilities.java
+++ b/editor/src/main/java/codes/nibby/yi/editor/utilities/ShapeUtilities.java
@@ -1,0 +1,127 @@
+package codes.nibby.yi.editor.utilities;
+
+import javafx.scene.shape.Rectangle;
+
+/**
+ * A collection of utilities that manipulate 2D geometry objects.
+ */
+public final class ShapeUtilities {
+
+    private ShapeUtilities() { }
+
+    /**
+     * Calculates the bounds of the component if it is centered relative to the container.
+     *
+     * @param container The container to center within
+     * @param component The component to center
+     * @return The bounds of the component after it is centered
+     */
+    public static Rectangle center(Rectangle container, Rectangle component) {
+        double x = container.getX() + container.getWidth() / 2 - component.getWidth() / 2;
+        double y = container.getY() + container.getHeight() / 2 - component.getHeight() / 2;
+        return new Rectangle(x, y, component.getWidth(), component.getHeight());
+    }
+
+    /**
+     * Finds the largest rectangle with the given width to height ratio that can fit inside the container.
+     *
+     * @param container The container to fit the rectangle within
+     * @param targetWidthToHeightRatio The width to height ratio of the fitted rectangle
+     * @param percentageInsets Amount of margin for the fitted rectangle on each side, expressed as a percentage of the shorter side of the container.
+     *                         For example, 0.05d (5%) on a 100x200 container means a margin of 5px on all sides of the fitted rectangle.
+     * @return The largest rectangle within the container that complies with the target width to height ratio
+     */
+    public static Rectangle centerFit(Rectangle container, double targetWidthToHeightRatio, double percentageInsets) {
+        boolean containerWidthWider = container.getWidth() > container.getHeight();
+        boolean fitWidthWider = targetWidthToHeightRatio > 1;
+
+        double fitInsets;
+
+        if (containerWidthWider) {
+            fitInsets = container.getHeight() * percentageInsets;
+        } else {
+            fitInsets = container.getWidth() * percentageInsets;
+        }
+
+        double fitWidth, fitHeight;
+        double scaleFactor;
+
+        if (fitWidthWider) {
+            // If fit by width, component size is constrained by height
+            fitWidth = container.getWidth();
+            fitHeight = fitWidth / targetWidthToHeightRatio;
+
+            scaleFactor = fitHeight / container.getHeight();
+        } else {
+            // If fit by height, component size is constrained by width
+            fitHeight = container.getHeight();
+            fitWidth = fitHeight * targetWidthToHeightRatio;
+
+            scaleFactor = fitWidth / container.getWidth();
+        }
+
+        if (scaleFactor > 1d) {
+            fitWidth /= scaleFactor;
+            fitHeight /= scaleFactor;
+        }
+
+        double fitX = container.getX() + container.getWidth() / 2 - fitWidth / 2;
+        double fitY = container.getY() + container.getHeight() / 2 - fitHeight / 2;
+
+        return new Rectangle(fitX + fitInsets, fitY + fitInsets, fitWidth - 2 * fitInsets, fitHeight - 2 * fitInsets);
+    }
+
+    /**
+     * Trims the given bounds on all four sides by an inset. The result is a smaller rectangle
+     * centered within bounds.
+     *
+     * @param bounds The bounds to trim
+     * @param insets Amount to trim from all sides on the bounds, in pixel units
+     * @return The clipped bounds
+     */
+    public static Rectangle clip(Rectangle bounds, double insets) {
+        return clip(bounds.getX(), bounds.getY(), bounds.getWidth(), bounds.getHeight(), insets);
+    }
+
+    /**
+     * Trims the given bounds on all four sides by an inset. The result is a smaller rectangle
+     * centered within bounds.
+     *
+     * @param x x position of the bound rectangle
+     * @param y y position of the bound rectangle
+     * @param w width of the bound rectangle
+     * @param h height of the bound rectangle
+     * @param insets Amount to trim from all sides on the bounds, in pixel units
+     * @return The clipped bounds
+     */
+    public static Rectangle clip(double x, double y, double w, double h, double insets) {
+        return clip(x, y, w, h, insets, insets, insets, insets);
+    }
+
+    /**
+     * Trims the given bounds on each side by a custom inset. The result is a smaller rectangle.
+     * </p>
+     * The rectangle is not guaranteed to be centered within the bounds if the amount trimmed on each side is not identical.
+     *
+     * @param x x position of the bound rectangle
+     * @param y y position of the bound rectangle
+     * @param w width of the bound rectangle
+     * @param h height of the bound rectangle
+     * @param insetLeft Amount to trim from left of the rectangle, in pixel units
+     * @param insetTop Amount to trim from top of the rectangle, in pixel units
+     * @param insetRight Amount to trim from right of the rectangle, in pixel units
+     * @param insetBottom Amount to trim from bottom of the rectangle, in pixel units
+     * @return The clipped bounds
+     */
+    public static Rectangle clip(double x, double y, double w, double h, double insetLeft, double insetTop, double insetRight, double insetBottom) {
+        double newX, newY, newWidth, newHeight;
+
+        newX = x + insetLeft;
+        newY = y + insetTop;
+        newWidth = w - (insetLeft + insetRight);
+        newHeight = h - (insetTop + insetBottom);
+
+        return new Rectangle(newX, newY, newWidth, newHeight);
+    }
+
+}

--- a/editor/test/unit/codes/nibby/yi/editor/gui/board/GameBoardMeasurementsTest.java
+++ b/editor/test/unit/codes/nibby/yi/editor/gui/board/GameBoardMeasurementsTest.java
@@ -1,6 +1,7 @@
 package codes.nibby.yi.editor.gui.board;
 
 import codes.nibby.yi.editor.utilities.ComparisonUtilities;
+import codes.nibby.yi.editor.utilities.ShapeUtilities;
 import javafx.scene.shape.Rectangle;
 import org.junit.jupiter.api.Test;
 
@@ -66,7 +67,7 @@ public final class GameBoardMeasurementsTest {
         Rectangle container = new Rectangle(0, 0, 100, 100);
         double fitWidthToHeightRatio = 1.0d;
 
-        Rectangle fit = GameBoardSize.centerFit(container, fitWidthToHeightRatio, 0d);
+        Rectangle fit = ShapeUtilities.centerFit(container, fitWidthToHeightRatio, 0d);
 
         testFitCorrect(new Rectangle(0, 0, 100, 100), fit);
     }
@@ -76,7 +77,7 @@ public final class GameBoardMeasurementsTest {
         Rectangle container = new Rectangle(0, 0, 100, 100);
         double fitWidthToHeightRatio = 2.0d;
 
-        Rectangle fit = GameBoardSize.centerFit(container, fitWidthToHeightRatio, 0d);
+        Rectangle fit = ShapeUtilities.centerFit(container, fitWidthToHeightRatio, 0d);
 
         testFitCorrect(new Rectangle(0, 25, 100, 50), fit);
     }
@@ -86,7 +87,7 @@ public final class GameBoardMeasurementsTest {
         Rectangle container = new Rectangle(0, 0, 100, 100);
         double fitWidthToHeightRatio = 0.5d;
 
-        Rectangle fit = GameBoardSize.centerFit(container, fitWidthToHeightRatio, 0d);
+        Rectangle fit = ShapeUtilities.centerFit(container, fitWidthToHeightRatio, 0d);
 
         testFitCorrect(new Rectangle(25, 0, 50, 100), fit);
     }
@@ -96,7 +97,7 @@ public final class GameBoardMeasurementsTest {
         Rectangle container = new Rectangle(0, 0, 200, 100);
         double fitWidthToHeightRatio = 1.0d;
 
-        Rectangle fit = GameBoardSize.centerFit(container, fitWidthToHeightRatio, 0d);
+        Rectangle fit = ShapeUtilities.centerFit(container, fitWidthToHeightRatio, 0d);
 
         testFitCorrect(new Rectangle(50, 0, 100, 100), fit);
     }
@@ -106,7 +107,7 @@ public final class GameBoardMeasurementsTest {
         Rectangle container = new Rectangle(0, 0, 200, 100);
         double fitWidthToHeightRatio = 2.0d;
 
-        Rectangle fit = GameBoardSize.centerFit(container, fitWidthToHeightRatio, 0d);
+        Rectangle fit = ShapeUtilities.centerFit(container, fitWidthToHeightRatio, 0d);
 
         testFitCorrect(new Rectangle(0, 0, 200, 100), fit);
     }
@@ -116,7 +117,7 @@ public final class GameBoardMeasurementsTest {
         Rectangle container = new Rectangle(0, 0, 200, 100);
         double fitWidthToHeightRatio = 0.5d;
 
-        Rectangle fit = GameBoardSize.centerFit(container, fitWidthToHeightRatio, 0d);
+        Rectangle fit = ShapeUtilities.centerFit(container, fitWidthToHeightRatio, 0d);
 
         testFitCorrect(new Rectangle(75, 0, 50, 100), fit);
     }
@@ -126,7 +127,7 @@ public final class GameBoardMeasurementsTest {
         Rectangle container = new Rectangle(0, 0, 100, 200);
         double fitWidthToHeightRatio = 1.0d;
 
-        Rectangle fit = GameBoardSize.centerFit(container, fitWidthToHeightRatio, 0d);
+        Rectangle fit = ShapeUtilities.centerFit(container, fitWidthToHeightRatio, 0d);
 
         testFitCorrect(new Rectangle(0, 50, 100, 100), fit);
     }
@@ -136,7 +137,7 @@ public final class GameBoardMeasurementsTest {
         Rectangle container = new Rectangle(0, 0, 100, 200);
         double fitWidthToHeightRatio = 2.0d;
 
-        Rectangle fit = GameBoardSize.centerFit(container, fitWidthToHeightRatio, 0d);
+        Rectangle fit = ShapeUtilities.centerFit(container, fitWidthToHeightRatio, 0d);
 
         testFitCorrect(new Rectangle(0, 75, 100, 50), fit);
     }
@@ -146,7 +147,7 @@ public final class GameBoardMeasurementsTest {
         Rectangle container = new Rectangle(0, 0, 100, 200);
         double fitWidthToHeightRatio = 0.5d;
 
-        Rectangle fit = GameBoardSize.centerFit(container, fitWidthToHeightRatio, 0d);
+        Rectangle fit = ShapeUtilities.centerFit(container, fitWidthToHeightRatio, 0d);
 
         testFitCorrect(new Rectangle(0, 0, 100, 200), fit);
     }
@@ -156,7 +157,7 @@ public final class GameBoardMeasurementsTest {
         Rectangle container = new Rectangle(0, 0, 100, 200);
         double fitWidthToHeightRatio = 0.5d;
 
-        Rectangle fit = GameBoardSize.centerFit(container, fitWidthToHeightRatio, 0.05d);
+        Rectangle fit = ShapeUtilities.centerFit(container, fitWidthToHeightRatio, 0.05d);
 
         testFitCorrect(new Rectangle(5, 5, 90, 190), fit);
     }


### PR DESCRIPTION
Added rendering for all the annotations except text-based labels, because an adequate font loading system has not been implemented.

Added follow-up issue at #28 to enable annotation editing. This issue is only concerned with the rendering aspect.

Closes #26.